### PR TITLE
feat: added support for replacing interpolated file paths in code files

### DIFF
--- a/docs/orca_data_definitions.md
+++ b/docs/orca_data_definitions.md
@@ -74,8 +74,11 @@ A `CodeFileInfo` contains a URL to files necessary to grade this submission. A M
 interface CodeFileInfo {
   url: string;
   mime_type: string;
+  should_replace_paths: boolean;
 }
 ```
+
+A given file may contain file paths to be updated for use on the grading VM. For example, `javac` can utilize a list of files for compilation. The `should_replace_paths` field indicates to the VM whether if a file should be updated.
 
 <hr>
 

--- a/grading-vm/orca_grader/container/build_script/code_file/code_file_info.py
+++ b/grading-vm/orca_grader/container/build_script/code_file/code_file_info.py
@@ -13,10 +13,12 @@ class CodeFileInfo:
     - The source of the code file. See ./code_file_source.py for more info.
   """
 
-  def __init__(self, url: str, mime_type: SubmissionMIMEType, source: CodeFileSource) -> None:
+  def __init__(self, url: str, mime_type: SubmissionMIMEType, 
+    save_dir_name: str, should_replace_paths: bool) -> None:
     self.__url = url
     self.__mime_type = mime_type
-    self.__source = source
+    self.__save_dir_name = save_dir_name
+    self.__should_replace_paths = should_replace_paths
 
   def get_url(self) -> str:
     return self.__url
@@ -24,14 +26,17 @@ class CodeFileInfo:
   def get_mime_type(self) -> SubmissionMIMEType:
     return self.__mime_type
   
-  def get_source(self) -> CodeFileSource:
-    return self.__source
+  def should_replace_paths(self) -> bool:
+    return self.__should_replace_paths
 
-  def get_save_dir(self, secret: str) -> str:
+  def get_save_dir_name(self) -> str:
+    return self.__save_dir_name
+
+  def get_save_path(self, secret: str) -> str:
     """
     Gets the name of the directory to save and extract files to.
     """
-    return f"{secret}_{self.__code_file_source.value}"
+    return f"{secret}_{self.__save_dir_name}"
   
   # https://stackoverflow.com/questions/18727347/how-to-extract-a-filename-from-a-url-append-a-word-to-it
   def get_file_name(self) -> str:
@@ -42,5 +47,6 @@ class CodeFileInfo:
     file_path = unquote(url_encoded_file_path)
     return basename(file_path)
 
-def json_to_code_file_info(json_code_file: CodeFileInfoJSON, source: str) -> CodeFileInfo:
-  return CodeFileInfo(json_code_file["url"], json_code_file["mime_type"], CodeFileSource(source))
+def json_to_code_file_info(json_code_file: CodeFileInfoJSON, dir_name: str) -> CodeFileInfo:
+  return CodeFileInfo(json_code_file["url"], json_code_file["mime_type"], 
+    dir_name, json_code_file["should_replace_paths"])

--- a/grading-vm/orca_grader/container/build_script/code_file/code_file_info.py
+++ b/grading-vm/orca_grader/container/build_script/code_file/code_file_info.py
@@ -31,12 +31,6 @@ class CodeFileInfo:
 
   def get_save_dir_name(self) -> str:
     return self.__save_dir_name
-
-  def get_save_path(self, secret: str) -> str:
-    """
-    Gets the name of the directory to save and extract files to.
-    """
-    return f"{secret}_{self.__save_dir_name}"
   
   # https://stackoverflow.com/questions/18727347/how-to-extract-a-filename-from-a-url-append-a-word-to-it
   def get_file_name(self) -> str:

--- a/grading-vm/orca_grader/container/build_script/code_file/processing/code_file_processor.py
+++ b/grading-vm/orca_grader/container/build_script/code_file/processing/code_file_processor.py
@@ -1,12 +1,16 @@
-from os.path import basename, join
+from functools import reduce
+import os
+from os import path
 from shutil import copyfileobj, copyfile
 import gzip
 import tarfile
+from typing import Dict
 from orca_grader.container.build_script.code_file.code_file_info import CodeFileInfo
 from orca_grader.container.build_script.code_file.sub_mime_types import SubmissionMIMEType
 from py7zr import SevenZipFile
 from zipfile import ZipFile
 import requests
+import fileinput
 
 def extract_tar_file(from_path: str, to_path: str) -> None:
   f = tarfile.open(from_path, "r:")
@@ -19,9 +23,9 @@ def extract_tar_gz_file(from_path: str, to_path: str) -> None:
   f.close()
 
 def extract_gz_file(from_path: str, to_path: str) -> None:
-  from_f_name = basename(from_path)
+  from_f_name = path.basename(from_path)
   f_in = gzip.open(from_path, "rb")
-  f_out = gzip.open(join(to_path, from_f_name))
+  f_out = gzip.open(path.join(to_path, from_f_name))
   copyfileobj(f_in, f_out)
   f_in.close()
   f_out.close()
@@ -38,23 +42,29 @@ def extract_7zip_file(from_path: str, to_path: str) -> None:
 
 class CodeFileProcessor:
 
+  def __init__(self, interpolated_dirs: Dict[str, str]) -> None:
+    self.__interpolated_dirs = interpolated_dirs
+
   def process_file(self, code_file: CodeFileInfo, download_dir: str, extraction_dir: str) -> None:
+    os.makedirs(download_dir)
+    os.makedirs(extraction_dir)
     downloaded_file_path = self._download_code_file(code_file, download_dir)
-    self._extract_code_file(code_file, downloaded_file_path, extraction_dir)
+    extracted_file_path = self._extract_code_file(code_file, downloaded_file_path, extraction_dir)
+    if code_file.should_replace_paths():
+      self.__replace_paths(extracted_file_path)
 
   # Useful to have this method as protected so that it can be overwritten in testing
   # (i.e., mock behavior for downloading can just be copying from a test fixture path).
   def _download_code_file(self, code_file: CodeFileInfo, download_path: str) -> str:
     file_name = code_file.get_file_name()
-    file_path = join(download_path, file_name)
+    file_path = path.join(download_path, file_name)
     with open(file_path, "wb") as f:
       web_reponse = requests.get(code_file.get_url())
       f.write(web_reponse.content)
       f.close()
     return file_path
 
-  # TODO: There is no *explicit* need for this to return a file path, however...should it?
-  def _extract_code_file(self, code_file: CodeFileInfo, from_path: str, to_path: str) -> None:
+  def _extract_code_file(self, code_file: CodeFileInfo, from_path: str, to_path: str) -> str:
     mime_to_extraction = {
       SubmissionMIMEType.TAR: extract_tar_file,
       SubmissionMIMEType.TAR_GZ: extract_gz_file,
@@ -67,3 +77,24 @@ class CodeFileProcessor:
       mime_to_extraction[mime_type](from_path, to_path)
     else:
       copyfile(from_path, to_path)
+    return path.join(to_path, code_file.get_file_name())
+  
+  def __replace_paths(self, file_path: str):
+    if path.isdir(file_path):
+      for file_name in os.scandir(file_path):
+        self.__replace_paths(path.join(file_path, file_name))
+    else:
+      file_name = path.basename(file_path)
+      dir_name = path.dirname(file_path)
+      edited_file_name = file_name + '_edited'
+      with open(file_path, 'r') as original_file:
+        with open(edited_file_name, 'w') as edited_file:
+          for line in original_file.readlines():
+            edited_file.write(
+              reduce(
+                lambda current, key: current.replace(key, self.__interpolated_dirs[key]), 
+                self.__interpolated_dirs,
+                line)
+            )
+      os.remove(file_path)
+      os.rename(path.join(dir_name, edited_file), file_path)

--- a/grading-vm/orca_grader/container/build_script/preprocess.py
+++ b/grading-vm/orca_grader/container/build_script/preprocess.py
@@ -15,7 +15,7 @@ DEFAULT_COMMAND_TIMEOUT = 60 # 1 minute
 class GradingScriptPreprocessor:
 
   def __init__(self, secret: str, json_cmds: List[GradingScriptCommandJSON], 
-    code_files: List[CodeFileInfo], file_processor: CodeFileProcessor, 
+    code_files: Dict[str, CodeFileInfo], code_file_processor: CodeFileProcessor, 
     cmd_timeout: int = DEFAULT_COMMAND_TIMEOUT) -> None:
     self.__interpolated_dirs = {
       "$ASSETS": "assets",
@@ -23,7 +23,7 @@ class GradingScriptPreprocessor:
       "$EXTRACTED": f"{secret}/extracted",
       "$BUILD": f"{secret}/build"
     }
-    self.__file_processing_command = file_processor
+    self.__code_file_processor = code_file_processor
     self.__json_cmds = json_cmds
     self.__code_files = code_files
     self.__cmds = [None for _ in range(len(json_cmds))]
@@ -43,13 +43,10 @@ class GradingScriptPreprocessor:
     self.__create_script_dirs()
     download_dir = self.__interpolated_dirs["$DOWNLOADED"]
     extract_dir = self.__interpolated_dirs["$EXTRACTED"]
-    for code_file in self.__code_files:
-      source_name = code_file.get_source().value
-      file_download_dir = os.path.join(download_dir, source_name)
-      file_extract_dir = os.path.join(extract_dir, source_name)
-      os.makedirs(file_download_dir)
-      os.makedirs(file_extract_dir)
-      self.__file_processing_command.process_file(code_file, file_download_dir, 
+    for name, code_file in self.__code_files.items():
+      file_download_dir = os.path.join(download_dir, name)
+      file_extract_dir = os.path.join(extract_dir, name)
+      self.__code_file_processor.process_file(code_file, file_download_dir, 
         file_extract_dir)
 
   def __generate_grading_script(self):

--- a/grading-vm/orca_grader/container/do_grading.py
+++ b/grading-vm/orca_grader/container/do_grading.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from typing import List, TextIO
+from typing import Dict, List, TextIO
 from orca_grader.common.services.push_results import push_results_to_bottlenose
 from orca_grader.container.exec_secret import GradingJobExecutionSecret
 from orca_grader.common.grading_job.grading_job_output import GradingJobOutput
@@ -9,7 +9,7 @@ from orca_grader.container.grading_script.grading_script_command_response import
 from orca_grader.container.build_script.preprocess import GradingScriptPreprocessor
 from orca_grader.container.build_script.code_file.processing.code_file_processor import CodeFileProcessor
 from orca_grader.container.build_script.exceptions import PreprocessingException
-from orca_grader.container.build_script.code_file.code_file_info import CodeFileInfo
+from orca_grader.container.build_script.code_file.code_file_info import CodeFileInfo, json_to_code_file_info
 from orca_grader.container.build_script.code_file.code_file_source import CodeFileSource
 from orca_grader.container.build_script.code_file.sub_mime_types import SubmissionMIMEType
 from orca_grader.common.types.grading_job_json_types import CodeFileInfoJSON, GradingJobJSON, GradingJobOutputJSON, GradingScriptCommandJSON
@@ -17,16 +17,9 @@ from orca_grader.common.types.grading_job_json_types import CodeFileInfoJSON, Gr
 def get_job_from_input_stream(input_stream: TextIO) -> GradingJobJSON:
   return json.load(input_stream)
 
-def extract_code_file_info_from_grading_job_json(grading_job_json: GradingJobJSON) -> List[CodeFileInfo]:
-  code_files: List[CodeFileInfo] = []
-  for source in [s.value for s in CodeFileSource]:
-      if source not in grading_job_json:
-        continue
-      json_code_file: CodeFileInfoJSON = grading_job_json[source]
-      code_file = CodeFileInfo(json_code_file["url"], SubmissionMIMEType(json_code_file["mime_type"]), 
-        CodeFileSource(source))
-      code_files.append(code_file)
-  return code_files
+def produce_code_files_dictionary(code_files_json: Dict[str, any]) -> Dict[str, CodeFileInfo]:
+  return { name: json_to_code_file_info(code_file_json, name) for (name, code_file_json) in code_files_json }
+    
 
 def do_grading(secret: str, grading_job_json: GradingJobJSON) -> GradingJobOutput:
   secret: str = GradingJobExecutionSecret.get_secret()
@@ -41,13 +34,20 @@ def do_grading(secret: str, grading_job_json: GradingJobJSON) -> GradingJobOutpu
   # *Handled outside in the "if name == '__main__'" section.
   try:
     # TODO: Pull credentials (e.g., submission id, student id, etc.) 
-    code_files = extract_code_file_info_from_grading_job_json(grading_job_json)
+    code_files = produce_code_files_dictionary(grading_job_json["code_files"])
     commands: List[GradingScriptCommandJSON] = grading_job_json["script"]
+    interpolated_dirs = {
+      "$ASSETS": "assets",
+      "$DOWNLOADED": f"{secret}/downloaded",
+      "$EXTRACTED": f"{secret}/extracted",
+      "$BUILD": f"{secret}/build"
+    }
     if "timeout" in grading_job_json:
-      preprocessor = GradingScriptPreprocessor(secret, commands, code_files, CodeFileProcessor(), 
-        grading_job_json["timeout"])
+      preprocessor = GradingScriptPreprocessor(secret, commands, code_files,
+        CodeFileProcessor(interpolated_dirs), grading_job_json["timeout"])
     else:
-      preprocessor = GradingScriptPreprocessor(secret, commands, code_files, CodeFileProcessor())
+      preprocessor = GradingScriptPreprocessor(secret, commands, code_files, 
+        CodeFileProcessor(interpolated_dirs))
     script: GradingScriptCommand = preprocessor.preprocess_job()
     output: GradingJobOutput = script.execute(command_responses)
   except PreprocessingException as preprocess_e:

--- a/grading-vm/orca_grader/validations/schemas/code_file_schema.json
+++ b/grading-vm/orca_grader/validations/schemas/code_file_schema.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "url": { "type": "string" },
-    "mime_type": { "type": "string" }
+    "mime_type": { "type": "string" },
+    "should_be_updated": { "type": "boolean" }
   },
   "required": ["url", "mime_type"]
 }


### PR DESCRIPTION
## Feature/Problem Description
Orca graders need to be able to support compilation (mainly from `javac`) through taking in a text file containing a number of file paths to be passed to a given compiler.

A grader should not only be able to receive this file in a given grading job, but it should also be able to replace file paths with those on the grader's running container.

## Solution (Changes Made)
- Changed the data definition for a `CodeFileInfo` object, which now takes in a `boolean` parameter to determine if it contains file paths that should be replaced.
- Rewrote the grading VM's definition of code files, updating it from a `List[CodeFileInfo]` to a `Dict[str, CodeFileInfo]`.
- Wrote a method to replace all the file path interpolated directories with those on the the grader's container.



